### PR TITLE
Update paragraaf "begrippenkader als dataset"

### DIFF
--- a/.checks/wcag-report.json
+++ b/.checks/wcag-report.json
@@ -4,7 +4,7 @@
     "id": "color-contrast",
     "impact": "serious",
     "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
-    "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=webdriverjs",
+    "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=webdriverjs",
     "nodes": [
       {
         "target": [
@@ -20,7 +20,7 @@
     "id": "scrollable-region-focusable",
     "impact": "serious",
     "description": "Ensure elements that have scrollable content are accessible by keyboard in Safari",
-    "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/scrollable-region-focusable?application=webdriverjs",
+    "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=webdriverjs",
     "nodes": [
       {
         "target": [

--- a/best-practices.md
+++ b/best-practices.md
@@ -385,16 +385,14 @@ Begrippen kunnen in meerdere begrippenkaders voorkomen. Maar worden in één dat
 
 ##### Begrippenkader als dataset
 
-In de paragraaf hierboven is onderscheid gemaakt tussen begrippenkader en dataset. Als dit onderscheid minder belangrijk is kan er gekozen worden om dat onderscheid niet te maken. Indien een begrippenkader ook beoogd is als de dataset, dan geldt *ook* nog de taalbinding:
+In de paragraaf hierboven is onderscheid gemaakt tussen begrippenkader en dataset. Als dit onderscheid minder belangrijk is kan er gekozen worden om dat onderscheid niet te maken. Indien een begrippenkader ook beoogd is als de dataset, dan geldt de taalbinding:
 - Begrippenkader = `skos:ConceptScheme` EN `dcat:Dataset`
 
 In het algemeen kun je stellen dat een object wordt beschreven in een gegevensobject en dit gegevensobject is onderdeel van een dataset. Dat is ook het patroon dat gehanteerd wordt voor het versiebeheer van begrippen(kaders).
 
 Cognitief maken mensen niet altijd een onderscheid tussen het ding-als-concept (“begrip”, “begrippenkader”, “taxonomie”, “lijstje”) en het ding-als-gegevensobject (waar dan dezelfde woorden worden gebruikt). We volgen dan een ander patroon voor versiebeheer. Het begrippenkader bevat begrippen én begripsbeschrijvingen. Dit maakt het begrippenkader zowel een 'conceptueel object' als een 'informatieobject'. Dit is een variatie op Variant B waarbij het begrippenkader én de begrippenkaderbeschrijving én de beheereenheid (of publicatieeenheid) dezelfde identiteit hebben.
 
-<aside class="note">Dit patroon voor versiebeheer, waarbij geen onderscheid wordt gemaakt tussen het object en het gegevensobject, wordt in technisch jargon ook wel <em>punning</em> genoemd. </aside>
-
-Het term "Begrippenkader" en synoniemen als "Taxonomie", "Thesaurus" of "Begrippenstelsel" zijn daarmee zowel bruikbaar voor situaties waarbij een abstracte verzameling van begrippen wordt bedoeld (via `skos:inScheme`) en voor situaties waar bij een verzameling van beschrijvingen van dergelijke begrippen wordt bedoeld (via `dcat:Dataset`). Alleen als in de taalbinding beide aanwezig zijn, is sprake van *punning* en wordt zowel een abstracte verzameling van begrippen bedoeld als een verzameling van beschrijvingen. Dit is een ruime opvatting van de definitie van begrippenkader maar dit wordt niet uitgesloten in SBB.
+Het term "Begrippenkader" en synoniemen als "Taxonomie", "Thesaurus" of "Begrippenstelsel" zijn daarmee zowel bruikbaar voor situaties waarbij een abstracte verzameling van begrippen wordt bedoeld (via `skos:inScheme`) en voor situaties waar bij een verzameling van beschrijvingen van dergelijke begrippen wordt bedoeld (via `dcat:Dataset`). Alleen als in de taalbinding beide aanwezig zijn, wordt zowel een abstracte verzameling van begrippen bedoeld als een verzameling van beschrijvingen. Dit is een ruime opvatting van de definitie van begrippenkader maar dit wordt niet uitgesloten in SBB.
 
 > Advies is om expliciet aan te geven bij de beschrijving van een begrippenkader of ook sprake is van een eenheid van beheer, publicatie of herkomst.
 

--- a/best-practices.md
+++ b/best-practices.md
@@ -409,11 +409,11 @@ Voor de taalbinding van herkomstinformatie wordt gebruik gemaakt van PROV:
 
 Voor de drie gedefinieerde variaties geven we een voorbeelduitwerking:
 
-- [Variant A](./sessies/metadata/versiebeheer/voorbeelduitwerkingen/VariantA.ttl) De begripsbeschrijving is de eenheid van beheer
-- [Variant B](./sessies/metadata/versiebeheer/voorbeelduitwerkingen/variantB.ttl) Het begrippenkader komt overeen met de eenheid van beheer
-- [Variant C](./sessies/metadata/versiebeheer/voorbeelduitwerkingen/VariantC.trig) Een deel van een complete begripsbeschrijving als eenheid van beheer
+- [Variant A](voorbeelduitwerkingen/VariantA.ttl) De begripsbeschrijving is de eenheid van beheer
+- [Variant B](voorbeelduitwerkingen/variantB.ttl) Het begrippenkader komt overeen met de eenheid van beheer
+- [Variant C](voorbeelduitwerkingen/VariantC.trig) Een deel van een complete begripsbeschrijving als eenheid van beheer
 
 Aanvullend geven we twee extra uitwerkingen:
 
-- [Variant B.1](./sessies/metadata/versiebeheer/voorbeelduitwerkingen/VariantB1.ttl) Het begrippenkader is óók de eenheid van beheer
-- [Variant B.2](./sessies/metadata/versiebeheer/voorbeelduitwerkingen/VariantB2.ttl) De beheereenheid is een verzameling begripsbeschrijvingen die niet overeenkomt met het begrippenkader
+- [Variant B.1](voorbeelduitwerkingen/VariantB1.ttl) Het begrippenkader is óók de eenheid van beheer
+- [Variant B.2](voorbeelduitwerkingen/VariantB2.ttl) De beheereenheid is een verzameling begripsbeschrijvingen die niet overeenkomt met het begrippenkader

--- a/best-practices.md
+++ b/best-practices.md
@@ -385,12 +385,14 @@ Begrippen kunnen in meerdere begrippenkaders voorkomen. Maar worden in één dat
 
 ##### Begrippenkader als dataset
 
-Een object is beschreven in een gegevensobject en dit gegevensobject is onderdeel van een dataset. Dat is het patroon wat gehanteerd wordt voor het versiebeheer van begrippen(kaders).
-
-Cognitief maken mensen niet altijd een onderscheid tussen het ding-als-concept (“begrip”, “begrippenkader”, “taxonomie”, “lijstje”) en het ding-als-informatieobject (waar dan dezelfde woorden worden gebruikt). Als dit onderscheid minder belangrijk is kan er gekozen worden om dat onderscheid niet te maken. We volgen dan een ander patroon voor versiebeheer. Technisch gezien leidt dit patroon tot punning. Het begrippenkader bevat begrippen én begripsbeschrijvingen. Dit maakt het begrippenkader zowel een 'conceptueel object' als een 'informatieobject'. Dit is een variatie op Variant B waarbij het begrippenkader én de begrippenkaderbeschrijving én de beheereenheid (of publicatieeenheid) dezelfde identiteit hebben.
-
-Indien een begrippenkader dus ook beoogd is als de dataset, dan geldt bovendien *ook* nog de taalbinding:
+In de paragraaf hierboven is onderscheid gemaakt tussen begrippenkader en dataset. Als dit onderscheid minder belangrijk is kan er gekozen worden om dat onderscheid niet te maken. Indien een begrippenkader ook beoogd is als de dataset, dan geldt *ook* nog de taalbinding:
 - Begrippenkader = `skos:ConceptScheme` EN `dcat:Dataset`
+
+In het algemeen kun je stellen dat een object wordt beschreven in een gegevensobject en dit gegevensobject is onderdeel van een dataset. Dat is ook het patroon dat gehanteerd wordt voor het versiebeheer van begrippen(kaders).
+
+Cognitief maken mensen niet altijd een onderscheid tussen het ding-als-concept (“begrip”, “begrippenkader”, “taxonomie”, “lijstje”) en het ding-als-gegevensobject (waar dan dezelfde woorden worden gebruikt). We volgen dan een ander patroon voor versiebeheer. Het begrippenkader bevat begrippen én begripsbeschrijvingen. Dit maakt het begrippenkader zowel een 'conceptueel object' als een 'informatieobject'. Dit is een variatie op Variant B waarbij het begrippenkader én de begrippenkaderbeschrijving én de beheereenheid (of publicatieeenheid) dezelfde identiteit hebben.
+
+<aside class="note">Dit patroon voor versiebeheer, waarbij geen onderscheid wordt gemaakt tussen het object en het gegevensobject, wordt in technisch jargon ook wel <em>punning</em> genoemd. </aside>
 
 Het term "Begrippenkader" en synoniemen als "Taxonomie", "Thesaurus" of "Begrippenstelsel" zijn daarmee zowel bruikbaar voor situaties waarbij een abstracte verzameling van begrippen wordt bedoeld (via `skos:inScheme`) en voor situaties waar bij een verzameling van beschrijvingen van dergelijke begrippen wordt bedoeld (via `dcat:Dataset`). Alleen als in de taalbinding beide aanwezig zijn, is sprake van *punning* en wordt zowel een abstracte verzameling van begrippen bedoeld als een verzameling van beschrijvingen. Dit is een ruime opvatting van de definitie van begrippenkader maar dit wordt niet uitgesloten in SBB.
 

--- a/snapshot.html
+++ b/snapshot.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><html lang="nl"><head>
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta content="text/html; charset=utf-8" http-equiv="content-type">
-<meta name="generator" content="ReSpec 35.8.0">
+<meta name="generator" content="ReSpec 37.2.0">
 <style>
 span.example-title{text-transform:none}
 :is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
@@ -36,6 +36,7 @@ dfn{cursor:pointer}
 .dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
 .dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
 .dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+.dfn-panel .marker.cddl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
 .dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
 .dfn-panel a[href]:hover{border-bottom-width:1px}
 .dfn-panel ul{padding:0}
@@ -78,13 +79,17 @@ a.bibref{text-decoration:none}
 .respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
 }
 #references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+@media (prefers-color-scheme:dark){
+#references :target{background:color-mix(in srgb, #eaf3ff 15%, transparent)}
+}
+body:has(input[name=color-scheme][value=dark]:checked) #references :target{background:color-mix(in srgb, #eaf3ff 15%, transparent)}
 cite .bibref{font-style:italic}
 a[href].orcid{padding-left:4px;padding-right:4px}
 a[href].orcid>svg{margin-bottom:-2px}
 ol.tof,ul.tof{list-style:none outside none}
 .caption{margin-top:.5em;font-style:italic}
 #issue-summary>ul{column-count:2}
-#issue-summary li{list-style:none;display:inline-block}
+#issue-summary li{list-style:none}
 details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
 details.respec-tests-details>*{padding-right:2em}
 details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
@@ -93,7 +98,8 @@ details.respec-tests-details>ul{width:100%;margin-top:-.3em}
 details.respec-tests-details>li{padding-left:1em}
 .self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
 aside.example .marker>a.self-link{color:inherit}
-.header-wrapper{display:flex;align-items:baseline;position:relative;left:-.5em}
+.header-wrapper{display:flex;align-items:baseline}
+:is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2):has(+a.self-link){position:relative;left:-.5em}
 :is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-.7em;font-size:1rem;opacity:.5}
 :is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
 :is(h2,h3)+a.self-link{top:-.2em}
@@ -104,6 +110,8 @@ dd{margin-left:0}
 @media print{
 .removeOnSave{display:none}
 }
+body:has(input[name=color-scheme][value=light]:checked),head:not(:has(meta[name=color-scheme][content~=dark]))+body{color-scheme:light}
+body:has(input[name=color-scheme][value=dark]:checked){color-scheme:dark}
 </style>
 <style id="respec-nlgov">
 img.license{float:left;padding-right:5px;background:0 0}
@@ -122,9 +130,36 @@ ul.index code{color:inherit}
 </style>
 <meta name="description" content="Dit document bevat best practices en optionele uitbreidingen voor de Standaard voor het beschrijven van begrippen [NLSBB].">
 <style>
-.hljs{--base:#fafafa;--mono-1:#383a42;--mono-2:#686b77;--mono-3:#717277;--hue-1:#0b76c5;--hue-2:#336ae3;--hue-3:#a626a4;--hue-4:#42803c;--hue-5:#ca4706;--hue-5-2:#c91243;--hue-6:#986801;--hue-6-2:#9a6a01}
+.hljs,body:has(input[name=color-scheme][value=light]:checked) .hljs,head:not(:has(meta[name=color-scheme][content~=dark]))+body .hljs{--base:#fafafa;--mono-1:#383a42;--mono-2:#686b77;--mono-3:#717277;--hue-1:#0b76c5;--hue-2:#336ae3;--hue-3:#a626a4;--hue-4:#42803c;--hue-5:#ca4706;--hue-5-2:#c91243;--hue-6:#986801;--hue-6-2:#9a6a01}
 @media (prefers-color-scheme:dark){
-.hljs{--base:#282c34;--mono-1:#abb2bf;--mono-2:#818896;--mono-3:#5c6370;--hue-1:#56b6c2;--hue-2:#61aeee;--hue-3:#c678dd;--hue-4:#98c379;--hue-5:#e06c75;--hue-5-2:#be5046;--hue-6:#d19a66;--hue-6-2:#e6c07b}
+.hljs{
+  --base: #282c34;
+  --mono-1: #abb2bf;
+  --mono-2: #818896;
+  --mono-3: #5c6370;
+  --hue-1: #56b6c2;
+  --hue-2: #61aeee;
+  --hue-3: #c678dd;
+  --hue-4: #98c379;
+  --hue-5: #e06c75;
+  --hue-5-2: #be5046;
+  --hue-6: #d19a66;
+  --hue-6-2: #e6c07b;
+}
+}
+body:has(input[name=color-scheme][value=dark]:checked) .hljs{
+  --base: #282c34;
+  --mono-1: #abb2bf;
+  --mono-2: #818896;
+  --mono-3: #5c6370;
+  --hue-1: #56b6c2;
+  --hue-2: #61aeee;
+  --hue-3: #c678dd;
+  --hue-4: #98c379;
+  --hue-5: #e06c75;
+  --hue-5-2: #be5046;
+  --hue-6: #d19a66;
+  --hue-6-2: #e6c07b;
 }
 .hljs{display:block;overflow-x:auto;padding:.5em;color:#383a42;color:var(--mono-1,#383a42);background:#fafafa;background:var(--base,#fafafa)}
 .hljs-comment,.hljs-quote{color:#717277;color:var(--mono-3,#717277);font-style:italic}
@@ -404,14 +439,14 @@ ul.index code{color:inherit}
 }</script>
 <link rel="stylesheet" href="https://tools.geostandaarden.nl/respec/style/base.css"></head>
 
-<body class="h-entry toc-inline"><div class="head">
+<body class="h-entry"><div class="head">
     <a class="logo" href="https://www.geonovum.nl/geo-standaarden"><img alt="Geonovum" height="67" id="Geonovum" src="https://docs.geostandaarden.nl/media/Geonovum.svg" width="132">
   </a> <h1 id="title" class="title">Best Practices en aanvullingen voor NL-SBB - Standaard voor het beschrijven van begrippen</h1>
     
     <h2>
       Geonovum Handreiking<br>
       Werkversie
-      <time class="dt-published" datetime="2026-05-18">18 mei 2026</time>
+      <time class="dt-published" datetime="2026-07-20">20 juli 2026</time>
     </h2>
     <dl>
       
@@ -469,7 +504,9 @@ ul.index code{color:inherit}
       <dt>Doe mee:</dt><dd>
     <a href="https://github.com/Geonovum/NL-SBB/">GitHub Geonovum/NL-SBB</a>
   </dd><dd>
-    <a href="https://github.com/Geonovum/NL-SBB/issues/">Dien een melding in</a>
+    <a href="https://github.com/Geonovum/NL-SBB/issues/">All issues</a>
+  </dd><dd>
+    <a href="https://github.com/Geonovum/NL-SBB/issues/new/choose">Dien een melding in</a>
   </dd><dd>
     <a href="https://github.com/Geonovum/NL-SBB/commits/">Revisiehistorie</a>
   </dd><dd>
@@ -506,25 +543,15 @@ ul.index code{color:inherit}
 <li>Gebruik enkelvoud. Dit geldt specifiek voor Duits, Frans, Nederlands, niet voor het Engels.</li>
 <li>Gebruik standaard spelling, conform het groene boekje.</li>
 </ul>
-<p></p></div>
-
-<div class="practice advisement"><a class="marker self-link" href="#bp-de-voorkeursterm-sluit-aan-op-de-daadwerkelijke-term-zoals-deze-lexicaal-gebruikt-wordt"><bdi lang="en">Best Practice 2</bdi></a>: <span class="practicelab" id="bp-de-voorkeursterm-sluit-aan-op-de-daadwerkelijke-term-zoals-deze-lexicaal-gebruikt-wordt">De voorkeursterm sluit aan op de daadwerkelijke term zoals deze lexicaal gebruikt wordt.</span><p class="practicedesc"></p><p>
+<p></p></div><div class="practice advisement"><a class="marker self-link" href="#bp-de-voorkeursterm-sluit-aan-op-de-daadwerkelijke-term-zoals-deze-lexicaal-gebruikt-wordt"><bdi lang="en">Best Practice 2</bdi></a>: <span class="practicelab" id="bp-de-voorkeursterm-sluit-aan-op-de-daadwerkelijke-term-zoals-deze-lexicaal-gebruikt-wordt">De voorkeursterm sluit aan op de daadwerkelijke term zoals deze lexicaal gebruikt wordt.</span><p class="practicedesc"></p><p>
 </p><ul>
 <li>Het is verplicht dat voor iedere taal alle voorkeurtermen die in één taal voorkomen in één begrippenkader uniek zijn. De voorkeursterm is de daadwerkelijke term zoals deze lexicaal gebruikt wordt, dus met spaties, diakrieten en hoofdletters bij namen.</li> 
 <li>Mocht binnen één begrippenkader toch twee begrippen terugkomen die vaak met dezelfde term worden aangeduid, dan is het noodzakelijk - om spraakverwarring te voorkomen - om een post of prefix toe te voegen als dit algemeen gebruikelijk is. Denk aan <i>Hengelo (OV)</i> voor de plaats in Overijssel en <i>Hengelo (GLD)</i> voor de plaats in Gelderland.</li> 
 <li>Mocht een post of prefix in de praktijk niet worden gebruikt, dan is dit een sterke aanwijzing dat de twee begrippen feitelijk niet tot hetzelfde begrippenkader behoren, en uit elkaar gehaald moeten worden. De basisregel blijft gelden.</li> 
 <li>Als begrippen in verschillende begrippenkaders zijn geplaatst, dan is een nadere aanduiding van de context ongewenst. Als een lexicale term toch nader gekwalificeerd wordt dan is het aangeraden om een meer generiekere of classificerende term te gebruiken en deze tussen haakjes achter de lexicale term te plaatsen in de term, conform ISO25964. E.g. <i>Bank (Zitobject)</i> en <i>Bank (Financiële instelling)</i>.</li>
 </ul>
-<p></p></div>
-
-<div class="practice advisement"><a class="marker self-link" href="#bp-maak-expliciet-voor-de-lezer-wanneer-in-een-zin-het-woord-zelf-en-niet-de-betekenis-van-het-woord-wordt-bedoeld"><bdi lang="en">Best Practice 3</bdi></a>: <span class="practicelab" id="bp-maak-expliciet-voor-de-lezer-wanneer-in-een-zin-het-woord-zelf-en-niet-de-betekenis-van-het-woord-wordt-bedoeld">Maak expliciet voor de lezer wanneer in een zin het woord zelf en niet de betekenis van het woord wordt bedoeld.</span><p class="practicedesc"></p><p>Wanneer een woord naar zichzelf verwijst, bijvoorbeeld in de zin "'Bank' is een zelfstandignaamwoord", dan zou dit moeten worden aangegeven met enkele of dubbele aanhalingsteken. Wanneer een term uit meerdere woorden bestaat en gebruikt wordt in een zin om een begrip aan te duiden zou dit kenbaar gemaakt moeten worden met guillemets (French quotation marks) «». Bijvoorbeeld «heeft bovenliggend begrip» relateert een begrip aan...". Dit zorgt ervoor dat er geen grammaticaal onlogische zinnen onstaan en dat de lezer de tekst beter begrijpt.</p></div>
-
-<div class="practice advisement"><a class="marker self-link" href="#bp-geef-bij-lexicale-labels-en-notities-aan-in-welke-taal-deze-gegeven-zijn"><bdi lang="en">Best Practice 4</bdi></a>: <span class="practicelab" id="bp-geef-bij-lexicale-labels-en-notities-aan-in-welke-taal-deze-gegeven-zijn">Geef bij lexicale labels en notities aan in welke taal deze gegeven zijn.
-</span><p class="practicedesc"></p><p>Voor labels moet aangegeven worden in welke taal deze gespecificeerd zijn.</p></div>
-
-<div class="practice advisement"><a class="marker self-link" href="#bp-in-rdf-is-het-gebruikelijk-om-ieder-begrip-een-naam-in-de-vorm-van-een-rdfs-label-te-geven-daarmee-kunnen-ook-interfaces-overweg-die-de-verschillende-soorten-termen-voorkeursterm-alternatieve-term-zoekterm-niet-kunnen-onderscheiden-daarmee-krijgt-ieder-begrip-een-leesbare-naam-ongeacht-de-context"><bdi lang="en">Best Practice 5</bdi></a>: <span class="practicelab" id="bp-in-rdf-is-het-gebruikelijk-om-ieder-begrip-een-naam-in-de-vorm-van-een-rdfs-label-te-geven-daarmee-kunnen-ook-interfaces-overweg-die-de-verschillende-soorten-termen-voorkeursterm-alternatieve-term-zoekterm-niet-kunnen-onderscheiden-daarmee-krijgt-ieder-begrip-een-leesbare-naam-ongeacht-de-context">In rdf is het gebruikelijk om ieder begrip een naam in de vorm van een rdfs:label te geven. Daarmee kunnen ook interfaces overweg die de verschillende soorten termen (voorkeursterm, alternatieve term, zoekterm) niet kunnen onderscheiden. Daarmee krijgt ieder begrip een leesbare naam, ongeacht de context.</span><p class="practicedesc"></p><p>Anders dan bij de voorkeursterm, is het verstandig om wel context in de naam mee te geven door bijvoorbeeld tussen haakjes deze context weert te geven, zoals bij <i>bank (financiële instelling)</i>. Daardoor ontstaat geen verwarring in het kader van homoniemen. De algemene naam bevordert tevens de compatibiliteit met bestaande tools. Het is denkbaar dat tools deze term afleiden van bijvoorbeeld de (Engelse) voorkeursterm of de code.</p></div>
-
-</section><section id="definities-en-uitleg"><div class="header-wrapper"><h4 id="x1-1-2-definities-en-uitleg"><bdi class="secno">1.1.2 </bdi>Definities en uitleg</h4><a class="self-link" href="#definities-en-uitleg" aria-label="Permalink for Section 1.1.2"></a></div>
+<p></p></div><div class="practice advisement"><a class="marker self-link" href="#bp-maak-expliciet-voor-de-lezer-wanneer-in-een-zin-het-woord-zelf-en-niet-de-betekenis-van-het-woord-wordt-bedoeld"><bdi lang="en">Best Practice 3</bdi></a>: <span class="practicelab" id="bp-maak-expliciet-voor-de-lezer-wanneer-in-een-zin-het-woord-zelf-en-niet-de-betekenis-van-het-woord-wordt-bedoeld">Maak expliciet voor de lezer wanneer in een zin het woord zelf en niet de betekenis van het woord wordt bedoeld.</span><p class="practicedesc"></p><p>Wanneer een woord naar zichzelf verwijst, bijvoorbeeld in de zin "'Bank' is een zelfstandignaamwoord", dan zou dit moeten worden aangegeven met enkele of dubbele aanhalingsteken. Wanneer een term uit meerdere woorden bestaat en gebruikt wordt in een zin om een begrip aan te duiden zou dit kenbaar gemaakt moeten worden met guillemets (French quotation marks) «». Bijvoorbeeld «heeft bovenliggend begrip» relateert een begrip aan...". Dit zorgt ervoor dat er geen grammaticaal onlogische zinnen onstaan en dat de lezer de tekst beter begrijpt.</p></div><div class="practice advisement"><a class="marker self-link" href="#bp-geef-bij-lexicale-labels-en-notities-aan-in-welke-taal-deze-gegeven-zijn"><bdi lang="en">Best Practice 4</bdi></a>: <span class="practicelab" id="bp-geef-bij-lexicale-labels-en-notities-aan-in-welke-taal-deze-gegeven-zijn">Geef bij lexicale labels en notities aan in welke taal deze gegeven zijn.
+</span><p class="practicedesc"></p><p>Voor labels moet aangegeven worden in welke taal deze gespecificeerd zijn.</p></div><div class="practice advisement"><a class="marker self-link" href="#bp-in-rdf-is-het-gebruikelijk-om-ieder-begrip-een-naam-in-de-vorm-van-een-rdfs-label-te-geven-daarmee-kunnen-ook-interfaces-overweg-die-de-verschillende-soorten-termen-voorkeursterm-alternatieve-term-zoekterm-niet-kunnen-onderscheiden-daarmee-krijgt-ieder-begrip-een-leesbare-naam-ongeacht-de-context"><bdi lang="en">Best Practice 5</bdi></a>: <span class="practicelab" id="bp-in-rdf-is-het-gebruikelijk-om-ieder-begrip-een-naam-in-de-vorm-van-een-rdfs-label-te-geven-daarmee-kunnen-ook-interfaces-overweg-die-de-verschillende-soorten-termen-voorkeursterm-alternatieve-term-zoekterm-niet-kunnen-onderscheiden-daarmee-krijgt-ieder-begrip-een-leesbare-naam-ongeacht-de-context">In rdf is het gebruikelijk om ieder begrip een naam in de vorm van een rdfs:label te geven. Daarmee kunnen ook interfaces overweg die de verschillende soorten termen (voorkeursterm, alternatieve term, zoekterm) niet kunnen onderscheiden. Daarmee krijgt ieder begrip een leesbare naam, ongeacht de context.</span><p class="practicedesc"></p><p>Anders dan bij de voorkeursterm, is het verstandig om wel context in de naam mee te geven door bijvoorbeeld tussen haakjes deze context weert te geven, zoals bij <i>bank (financiële instelling)</i>. Daardoor ontstaat geen verwarring in het kader van homoniemen. De algemene naam bevordert tevens de compatibiliteit met bestaande tools. Het is denkbaar dat tools deze term afleiden van bijvoorbeeld de (Engelse) voorkeursterm of de code.</p></div></section><section id="definities-en-uitleg"><div class="header-wrapper"><h4 id="x1-1-2-definities-en-uitleg"><bdi class="secno">1.1.2 </bdi>Definities en uitleg</h4><a class="self-link" href="#definities-en-uitleg" aria-label="Permalink for Section 1.1.2"></a></div>
 <p>Verschillende organisaties hebben uitgewerkte conventies voor het formuleren van een definitie. Deze conventies zijn één-op-één ook toepasbaar op het formuleren van een goede uitleg in begrijpelijke taal.</p>
 <section id="iso-704"><div class="header-wrapper"><h5 id="x1-1-2-1-iso-704"><bdi class="secno">1.1.2.1 </bdi>ISO:704</h5><a class="self-link" href="#iso-704" aria-label="Permalink for Section 1.1.2.1"></a></div>
 <p>In de NORA werkgroep begrippenkader hanteert men de <a href="https://www.iso.org/obp/ui/en/#iso:std:iso:704:ed-4:v1:en">ISO 704</a>. Een samenvatting daarvan is te vinden op <a href="https://www.noraonline.nl/wiki/Expertgroep_NORA_Begrippenkader_20231003#ISO_704">https://www.noraonline.nl/wiki/Expertgroep_NORA_Begrippenkader_20231003#ISO_704</a></p>
@@ -575,14 +602,10 @@ In de praktijk blijkt het heel lastig om goede definities op te stellen. Dit voo
 <p>Het Bureau Krediet Registratie (BKR) gebruikt <a href="https://www.brsolutions.com/wp-content/uploads/2016/10/How-to-Define-Business-Terms-Primer.pdf">https://www.brsolutions.com/wp-content/uploads/2016/10/How-to-Define-Business-Terms-Primer.pdf</a>.</p>
 </section></section><section id="hierarchische-relaties"><div class="header-wrapper"><h4 id="x1-1-3-hierarchische-relaties"><bdi class="secno">1.1.3 </bdi>Hiërarchische relaties</h4><a class="self-link" href="#hierarchische-relaties" aria-label="Permalink for Section 1.1.3"></a></div>
 <p>Het is toegestaan dat één begrip meerdere bovenliggende begrippen kent. Er is zo sprake van een <a data-link-type="dfn|abstract-op" href="#dfn-polyhierarchy" class="internalDFN" id="ref-for-dfn-polyhierarchy-1">polyhierarchy</a>. Een polyhiërarchie kan nuttig zijn omdat het een intuïtieve manier biedt om een begrip in meerdere categorieën te plaatsen. Veelal zie je dit dan ook toegepast in e-commerce. Hierdoor kunnen gebruikers via verschillende paden een bepaald product vinden. Toch wordt geadviseerd om hier terughoudend mee te zijn en bij het maken rekening te blijven houden met best-practices en standaarden op dit gebied.</p>
-<div class="definitie">Een <dfn id="dfn-polyhierarchy" tabindex="0" aria-haspopup="dialog">polyhierarchy</dfn> refereert naar aan hiërarchische structuur waar het is toegestaan dat een begrip meerdere bovenliggende begrippen heeft. Tegenovergesteld is een monohierarchy, waar ieder begrip niet meer dan één bovenliggend begrip kent.</div>
-
-</section></section><section id="bronnen"><div class="header-wrapper"><h3 id="x1-2-bronnen"><bdi class="secno">1.2 </bdi>Bronnen</h3><a class="self-link" href="#bronnen" aria-label="Permalink for Section 1.2"></a></div>
+<div class="definitie">Een <dfn data-noexport="" id="dfn-polyhierarchy" tabindex="0" aria-haspopup="dialog">polyhierarchy</dfn> refereert naar aan hiërarchische structuur waar het is toegestaan dat een begrip meerdere bovenliggende begrippen heeft. Tegenovergesteld is een monohierarchy, waar ieder begrip niet meer dan één bovenliggend begrip kent.</div></section></section><section id="bronnen"><div class="header-wrapper"><h3 id="x1-2-bronnen"><bdi class="secno">1.2 </bdi>Bronnen</h3><a class="self-link" href="#bronnen" aria-label="Permalink for Section 1.2"></a></div>
 <p>Een begrip kan zijn ontleend aan een op het web vindbare bron. Dit kan een (versie van) een bepaald werk zijn of een ander documentair iets waarin een beschrijving van het begrip is te vinden. Bronnen kunnen wel of niet beschreven zijn in RDF. Ook kan een begrip ontleend zijn aan een niet op het web vindbare bron. </p>
-<div class="note" role="note" id="issue-container-generatedID"><div role="heading" class="note-title marker" id="h-note" aria-level="4"><span>Noot</span></div><p class="">Veelal gaat 'ontleend' hier over de betekenis van het begrip. Niet direct de definitie. Er ontbreekt namelijk vaak een bron waar de definitie letterlijk in voorkomt, en anders is het zelfs zo dat de bron daarvoor een net iets andere verwoording gebruikt. We hebben het daarom over de bron van de betekenis; en niet over bijvoorbeeld de bron van de definitie. Ook kunnen andere kenmerken kunnen ontleend zijn aan een bron; zoals een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn">alternatieve term</a> of een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-0">code</a>.
-</p></div>
-
-<p>In ieder scenario willen we voldoende informatie hebben over de bron zodat we deze kunnen vinden. Dit kan op basis van een <em><a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-1">url</a></em> of een <em><a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-2">bronverwijzing</a></em>. 
+<div class="note" role="note" id="issue-container-generatedID"><div role="heading" class="note-title marker" id="h-note" aria-level="4"><span>Noot</span></div><p class="">Veelal gaat 'ontleend' hier over de betekenis van het begrip. Niet direct de definitie. Er ontbreekt namelijk vaak een bron waar de definitie letterlijk in voorkomt, en anders is het zelfs zo dat de bron daarvoor een net iets andere verwoording gebruikt. We hebben het daarom over de bron van de betekenis; en niet over bijvoorbeeld de bron van de definitie. Ook kunnen andere kenmerken kunnen ontleend zijn aan een bron; zoals een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn">alternatieve term</a> of een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-0">code</a>.
+</p></div><p>In ieder scenario willen we voldoende informatie hebben over de bron zodat we deze kunnen vinden. Dit kan op basis van een <em><a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-1">url</a></em> of een <em><a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-2">bronverwijzing</a></em>. 
 In het eenvoudigste geval is de bron vindbaar op het web en is het voldoende om als bronverwijzing de bijbehorende url op te nemen. De verwachting is dat middels deze url een mensleesbare representatie van het document gevonden kan worden. Dit kan er als volgt uit zien.</p>
 <div class="example" id="example-1">
         <div class="marker">
@@ -590,14 +613,10 @@ In het eenvoudigste geval is de bron vindbaar op het web en is het voldoende om 
   </div> <pre aria-busy="false"><code class="hljs css">ex:ingezetene a skos:Concept ;
   skos:definition <span class="hljs-string">"Zij die hun werkelijke woonplaats in de gemeente hebben"</span>@nl ;
   dct:source &lt;https://wetten.overheid.nl/jci1.<span class="hljs-number">3</span>:c:BWBR0005416&amp;titeldeel=I&amp;artikel=<span class="hljs-number">2</span>&amp;z=<span class="hljs-number">2022</span>-<span class="hljs-number">05</span>-<span class="hljs-number">01</span>&amp;g=<span class="hljs-number">2022</span>-<span class="hljs-number">05</span>-<span class="hljs-number">01</span>&gt;</code></pre>
-      </div>
-
-<p>Op deze manier is goed aangeven waar de betekenis van het begrip (gedocumenteerd als definitie) op gebaseerd is. Verder is er geen informatie over de bron. Wanneer de bron is beschreven in RDF is deze informatie er wel en kan dit meegenomen worden in de interpretatie van het begrip. </p>
+      </div><p>Op deze manier is goed aangeven waar de betekenis van het begrip (gedocumenteerd als definitie) op gebaseerd is. Verder is er geen informatie over de bron. Wanneer de bron is beschreven in RDF is deze informatie er wel en kan dit meegenomen worden in de interpretatie van het begrip. </p>
 <p>Wanneer een bron als linked data op het web ontsloten is neem je als waarde van bronverwijzing de URI van de bron. Dit kan bijvoorbeeld een instantie van <code>foaf:Document</code> of <code>dct:BibliographicResource</code> zijn. Hoe deze precies is beschreven is maakt voor de bronverwijzing niet uit, maar binnen dit profiel wordt de <a href="#specificatie-brondocument">specificatie voor bronnen</a> aangeraden.</p>
-<p>Het komt ook voor dat de bron niet vindbaar is op het web en/of niet als linked data ontsloten is. In dat geval kan de beheerder van het begrip zelf een beschrijving van de bron maken. De beschrijving bestaat minimaal uit een aanduiding van het brondocument en de naam. Als aanduiding van het brondocument kunnen in Linked data URI's of blanknodes gebruikt worden. Deze aanduiding is een directe identicatie van het brondocument (zie ook <a href="https://bp4mc2.org/modeling/">Fundamentals of Linked Data Modeling</a>). De beheerder van het begrip maakt een URI (of blank node) voor het brondocument wat het gebruikt, maar waar het niet de eigenaar van is. Dit is conform een van de basisprincipes van Linked Data, <em>Anybody can say anything about anything</em>. Deze URI kan alleen niet direct gebruikt worden om een mensleesbaar document te vinden. Wanneer de bron vindbaar is op het web kan foaf:page (<a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-3">url</a>) gebruikt worden om naar deze vindplaats te verwijzen. Wanneer de bron niet op het web vindbaar is, kan dct:bibliographicCitation (<a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-4">bronverwijzing</a>) gebruikt worden om citeerinformatie vast te leggen. Het kan zijn dat een bron zowel een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-5">url</a> als een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-6">bronverwijzing</a> kent.</p>
-<div class="practice advisement" id="conv-lido"><a class="marker self-link" href="#bp-conventie-verwijzing-wet-en-regelgeving"><bdi lang="en">Best Practice 6</bdi></a>: <span class="practicelab" id="bp-conventie-verwijzing-wet-en-regelgeving">Conventie verwijzing wet- en regelgeving</span><p class="practicedesc">Voor verwijzingen naar wet- en regelgeving moet <a href="http://wetten.overheid.nl/BWBR0005730/2022-04-01/#Hoofdstuk3_Paragraaf3.3">§ 3.3 Aanwijzingen voor de regelgeving</a> gevolgd worden. Met behulp van de Linktool van LiDO is het eenvoudig om verwijzingen te maken die aan de aanwijzingen voor de regelgeving voldoen.</p></div>
-
-<p>In het volgende voorbeeld zien we een beschrijving van een op het web vindbare bron die door de beheerder van het begrip is opgesteld. De beheerder is eigenaar van de beschrijving; maar niet van de bron zelf.</p>
+<p>Het komt ook voor dat de bron niet vindbaar is op het web en/of niet als linked data ontsloten is. In dat geval kan de beheerder van het begrip zelf een beschrijving van de bron maken. De beschrijving bestaat minimaal uit een aanduiding van het brondocument en de naam. Als aanduiding van het brondocument kunnen in Linked data URI's of blanknodes gebruikt worden. Deze aanduiding is een directe identicatie van het brondocument (zie ook <a href="https://bp4mc2.org/modeling/">Fundamentals of Linked Data Modeling</a>). De beheerder van het begrip maakt een URI (of blank node) voor het brondocument wat het gebruikt, maar waar het niet de eigenaar van is. Dit is conform een van de basisprincipes van Linked Data, <em>Anybody can say anything about anything</em>. Deze URI kan alleen niet direct gebruikt worden om een mensleesbaar document te vinden. Wanneer de bron vindbaar is op het web kan foaf:page (<a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-3">url</a>) gebruikt worden om naar deze vindplaats te verwijzen. Wanneer de bron niet op het web vindbaar is, kan dct:bibliographicCitation (<a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-4">bronverwijzing</a>) gebruikt worden om citeerinformatie vast te leggen. Het kan zijn dat een bron zowel een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-5">url</a> als een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-6">bronverwijzing</a> kent.</p>
+<div class="practice advisement" id="conv-lido"><a class="marker self-link" href="#bp-conventie-verwijzing-wet-en-regelgeving"><bdi lang="en">Best Practice 6</bdi></a>: <span class="practicelab" id="bp-conventie-verwijzing-wet-en-regelgeving">Conventie verwijzing wet- en regelgeving</span><p class="practicedesc">Voor verwijzingen naar wet- en regelgeving moet <a href="http://wetten.overheid.nl/BWBR0005730/2022-04-01/#Hoofdstuk3_Paragraaf3.3">§ 3.3 Aanwijzingen voor de regelgeving</a> gevolgd worden. Met behulp van de Linktool van LiDO is het eenvoudig om verwijzingen te maken die aan de aanwijzingen voor de regelgeving voldoen.</p></div><p>In het volgende voorbeeld zien we een beschrijving van een op het web vindbare bron die door de beheerder van het begrip is opgesteld. De beheerder is eigenaar van de beschrijving; maar niet van de bron zelf.</p>
 <div class="example" id="example-2">
         <div class="marker">
     <a class="self-link" href="#example-2">Voorbeeld<bdi> 2</bdi></a>
@@ -610,9 +629,7 @@ ex:GemeentewetArt2 a dct:BibliographicResource ;
   foaf:page &lt;https://wetten.overheid.nl/jci1.<span class="hljs-number">3</span>:c:BWBR0005416&amp;titeldeel=I&amp;artikel=<span class="hljs-number">2</span>&amp;z=<span class="hljs-number">2022</span>-<span class="hljs-number">05</span>-<span class="hljs-number">01</span>&amp;g=<span class="hljs-number">2022</span>-<span class="hljs-number">05</span>-<span class="hljs-number">01</span>&gt;  ;
   rdfs:comment <span class="hljs-string">"In deze wet wordt verstaan onder ingezetenen: zij die hun werkelijke woonplaats in de gemeente hebben."</span>@nl ;
   dct:type &lt;http://id.loc.gov/vocabulary/marcgt/leg&gt; .</code></pre>
-      </div>
-
-<p>De beschrijving van een niet op het web vindbare bron waarbij gekozen is voor het gebruik van een blank node kan er als volgt uit zien;</p>
+      </div><p>De beschrijving van een niet op het web vindbare bron waarbij gekozen is voor het gebruik van een blank node kan er als volgt uit zien;</p>
 <div class="example" id="example-3">
         <div class="marker">
     <a class="self-link" href="#example-3">Voorbeeld<bdi> 3</bdi></a>
@@ -628,9 +645,7 @@ ex:GemeentewetArt2 a dct:BibliographicResource ;
 <p>Wel biedt dit profiel een aantal aanbevelingen.</p>
 <div class="practice advisement"><a class="marker self-link" href="#bp-het-is-aanbevolen-om-bronnen-te-typeren-als-foaf-document"><bdi lang="en">Best Practice 7</bdi></a>: <span class="practicelab" id="bp-het-is-aanbevolen-om-bronnen-te-typeren-als-foaf-document">Het is aanbevolen om bronnen te typeren als foaf:Document</span><p class="practicedesc">Vooral omdat dit de meest laagdrempelige typering is aan de hand van bestaande vocabulaire.</p></div>
 <div class="practice advisement"><a class="marker self-link" href="#bp-het-is-aanbevolen-om-de-dcterms-vocabulaire-te-gebruiken-om-bronnen-te-beschrijven"><bdi lang="en">Best Practice 8</bdi></a>: <span class="practicelab" id="bp-het-is-aanbevolen-om-de-dcterms-vocabulaire-te-gebruiken-om-bronnen-te-beschrijven">Het is aanbevolen om de [<cite><a class="bibref" data-link-type="biblio" href="#bib-dcterms" title="DCMI Metadata Terms">DCTERMS</a></cite>] vocabulaire te gebruiken om bronnen te beschrijven.</span><p class="practicedesc"></p></div>
-<div class="practice advisement"><a class="marker self-link" href="#bp-het-is-aanbevolen-om-bronnen-met-_dct-type_-te-classificeren"><bdi lang="en">Best Practice 9</bdi></a>: <span class="practicelab" id="bp-het-is-aanbevolen-om-bronnen-met-_dct-type_-te-classificeren">Het is aanbevolen om bronnen met _dct:type_ te classificeren</span><p class="practicedesc">Dit doen we aan de hand van een gecontroleerd vocabulaire, ofwel een classificatie schema. Een voorbeeld van zo'n classificatie schema is <a href="http://id.loc.gov/vocabulary/marcgt">MARC Genre/Terms Scheme</a>. Dit is in aanvulling op een <code>rdf:type</code> typering.</p></div>
-
-</section></section><section id="harmonisatie-en-hergebruik"><div class="header-wrapper"><h3 id="x1-3-harmonisatie-en-hergebruik"><bdi class="secno">1.3 </bdi>Harmonisatie en hergebruik</h3><a class="self-link" href="#harmonisatie-en-hergebruik" aria-label="Permalink for Section 1.3"></a></div>
+<div class="practice advisement"><a class="marker self-link" href="#bp-het-is-aanbevolen-om-bronnen-met-_dct-type_-te-classificeren"><bdi lang="en">Best Practice 9</bdi></a>: <span class="practicelab" id="bp-het-is-aanbevolen-om-bronnen-met-_dct-type_-te-classificeren">Het is aanbevolen om bronnen met _dct:type_ te classificeren</span><p class="practicedesc">Dit doen we aan de hand van een gecontroleerd vocabulaire, ofwel een classificatie schema. Een voorbeeld van zo'n classificatie schema is <a href="http://id.loc.gov/vocabulary/marcgt">MARC Genre/Terms Scheme</a>. Dit is in aanvulling op een <code>rdf:type</code> typering.</p></div></section></section><section id="harmonisatie-en-hergebruik"><div class="header-wrapper"><h3 id="x1-3-harmonisatie-en-hergebruik"><bdi class="secno">1.3 </bdi>Harmonisatie en hergebruik</h3><a class="self-link" href="#harmonisatie-en-hergebruik" aria-label="Permalink for Section 1.3"></a></div>
 <p>Om data goed te kunnen gebruiken, maar zeker ook om data te combineren met andere data is het belangrijk om deze te begrijpen. 
 Begrippenkaders versterken de interoperabiliteit van datasets omdat het duidelijk maakt wat de betekenis is van termen die gebruikt worden.
 Een vooralsnog belangrijk thema in data is silo-vorming en organisaties zijn ook nadrukkelijk bezig om silo's te ontmantelen omdat data in samenhang meer waarde kan leveren. Om data in samenhang te kunnen bevragen is het noodzakelijk dat de terminologie eenduidig is en op elkaar aansluit. We hebben daarom niet alleen afzonderlijke begrippenkaders per registratie (bijvoorbeeld het begrippenkader van de BRK) nodig maar juist een stelsel van verbonden begrippenkaders per domein (bijvoorbeeld het vastgoed domein). </p>
@@ -641,7 +656,7 @@ Een vooralsnog belangrijk thema in data is silo-vorming en organisaties zijn ook
 <li>door begrippen te harmoniseren, en</li>
 <li>door begrippen te hergebruiken</li>
 </ol>
-<p>Wanneer we het hebben over een begrip dat gedefinieerd is in een 'andere context' dan noemen we dat voor het gemak een <dfn id="dfn-extern-begrip" tabindex="0" aria-haspopup="dialog">extern begrip</dfn>. </p>
+<p>Wanneer we het hebben over een begrip dat gedefinieerd is in een 'andere context' dan noemen we dat voor het gemak een <dfn data-noexport="" id="dfn-extern-begrip" tabindex="0" aria-haspopup="dialog">extern begrip</dfn>. </p>
 <section id="harmonisatie"><div class="header-wrapper"><h4 id="x1-3-1-harmonisatie"><bdi class="secno">1.3.1 </bdi>Harmonisatie</h4><a class="self-link" href="#harmonisatie" aria-label="Permalink for Section 1.3.1"></a></div>
 <p>Onder de noemer harmonisatie beschrijven we hoe begrippen uit verschillende begrippenkaders op basis van betekenis aan elkaar kunnen worden gerelateerd. De letterlijke betekenis van harmoniseren is 'op elkaar afstemmen'. Verbinden is een eerste stap op weg naar afstemmen, maar het is strikt genomen geen afstemming en dus ook geen harmonisatie.
 Daarom gebruiken we nadrukkelijk geen owl:sameAs gezien dat impliceert dat de twee resources op alle mogelijke manieren identiek zijn (sterker nog; het zijn dezelfde resources). Ook als twee begrippen exact dezelfde betekenis hebben kunnen ze verschillende lexicale namen, eigenaren en documentatie hebben. Ook zijn de logische gevolgen van owl:sameAs hierdoor veelal ongewenst. Een voorbeeld van een ongewenste implicatie is dat het kan leiden tot meerdere voorkeurstermen per taal voor een begrip en dit is niet toegestaan. Dit zien we bijvoorbeeld bij de volgende set statements:</p>
@@ -657,9 +672,7 @@ ex2:C a skos:Concept ;
   skos:inScheme ex2:BegrippenkaderB .
 
 ex:B owl:sameAs ex2:C .</code></pre>
-      </div>
-
-<p>wat impliceert:</p>
+      </div><p>wat impliceert:</p>
 <div class="example" id="example-5">
         <div class="marker">
     <a class="self-link" href="#example-5">Voorbeeld<bdi> 5</bdi></a>
@@ -674,12 +687,10 @@ ex2:C a skos:Concept ;
   skos:prefLabel <span class="hljs-string">"Bouwwerk"</span>@nl ;
   skos:inScheme ex2:BegrippenkaderB
   skos:inScheme ex:BegrippenkaderA .</code></pre>
-      </div>
-
-<p>N.B. Voorbeeld 4 en 5 zijn eigenlijk geen voorbeelden, maar contra-voorbeelden. Ze laten zien hoe het niet moet en wat er dan mis kan gaan.</p>
-<p>Als alternatief op owl:sameAs zijn harmonisatierelaties gedefinineerd in SKOS. Deze relaties worden gebruik om de mapping tussen begrippen in verschillende begrippenkaders vast te leggen wanneer deze een vergelijkbare betekenis hebben. Bijvoorbeeld door te stellen dat het begrip "Woning" uit één begrippenkader een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-7">heeft overeenkomstig bovenliggend</a> begrip «Pand» kent uit een ander begrippenkader.
+      </div><p>N.B. Voorbeeld 4 en 5 zijn eigenlijk geen voorbeelden, maar contra-voorbeelden. Ze laten zien hoe het niet moet en wat er dan mis kan gaan.</p>
+<p>Als alternatief op owl:sameAs zijn harmonisatierelaties gedefinineerd in SKOS. Deze relaties worden gebruik om de mapping tussen begrippen in verschillende begrippenkaders vast te leggen wanneer deze een vergelijkbare betekenis hebben. Bijvoorbeeld door te stellen dat het begrip "Woning" uit één begrippenkader een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-7">heeft overeenkomstig bovenliggend</a> begrip «Pand» kent uit een ander begrippenkader.
 We nemen zo het begrip «Pand» niet op in het begrippenkader waar "Woning" gedefinieerd is. Op dezelfde wijze kunnen twee begrippen uit verschillende begrippenkaders gerelateerd zijn aan elkaar. </p>
-<p>Bij het harmoniseren van begrippenkaders blijft er binnen ieder begrippenkader controle over de beschrijving van de begrippen. Zelfs bij een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-8">is exact overeenkomstig</a> relatie kunnen de betreffende begrippen verschillende voorkeurstermen hebben. De mapping ligt namelijk op de betekenis van het begrip en niet op de gerelateerde lexicale namen of documentatie bij het begrip. Op deze manier kan je bijvoorbeeld twee contexten op elkaar laten aansluiten waar verschillende voorkeurstermen dezelfde betekenis dragen zonder het taalgebruik van de betreffende domeinen aan te passen. Bijvoorbeeld omdat er vanuit één begrippenkader geen invloed uitgeoefend kan worden op het andere begrippenkader of omdat er twee perspectieven bestaan op één domein.
+<p>Bij het harmoniseren van begrippenkaders blijft er binnen ieder begrippenkader controle over de beschrijving van de begrippen. Zelfs bij een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-8">is exact overeenkomstig</a> relatie kunnen de betreffende begrippen verschillende voorkeurstermen hebben. De mapping ligt namelijk op de betekenis van het begrip en niet op de gerelateerde lexicale namen of documentatie bij het begrip. Op deze manier kan je bijvoorbeeld twee contexten op elkaar laten aansluiten waar verschillende voorkeurstermen dezelfde betekenis dragen zonder het taalgebruik van de betreffende domeinen aan te passen. Bijvoorbeeld omdat er vanuit één begrippenkader geen invloed uitgeoefend kan worden op het andere begrippenkader of omdat er twee perspectieven bestaan op één domein.
 Ook in situaties waar eenzelfde term in twee overlappende contexten net een specifiekere/andere betekenis heeft kan je er voor kiezen om twee begrippen te onderkennen en deze te harmoniseren. In dit geval kunnen kunnen harmonisatierelaties gebruikt worden. Bijvoorbeeld twee contexten (ex: en ex2:) waar de term land gebruikt wordt. </p>
 <div class="example" id="example-6">
         <div class="marker">
@@ -691,13 +702,9 @@ Ook in situaties waar eenzelfde term in twee overlappende contexten net een spec
 ex2:Land a skos:Concept
   skos:closeMatch ex:Land .
   skos:definition <span class="hljs-string">"Een land is een gebied dat in ISO 3166-1 als land wordt beschouwd."</span>@nl .</code></pre>
-      </div>
-
-<p>Het harmoniseren van begrippen is binnen één samenwerkingsverband of organisatie vaak niet het eindoel, maar een (belangrijke) tussenstap. Wanneer het duidelijk is wat de overlap tussen twee begrippenkaders precies is, is het pas mogelijk om tot een samenhangend netwerk of stelsel van begrippen te komen. Het harmoniseren van begrippenkaders kan dus een eerste stap zijn naar het kunnen herbruiken van externe begrippen. Dit wordt nader toegelicht in <a href="#hergebruik">hergebruik</a>.</p>
+      </div><p>Het harmoniseren van begrippen is binnen één samenwerkingsverband of organisatie vaak niet het eindoel, maar een (belangrijke) tussenstap. Wanneer het duidelijk is wat de overlap tussen twee begrippenkaders precies is, is het pas mogelijk om tot een samenhangend netwerk of stelsel van begrippen te komen. Het harmoniseren van begrippenkaders kan dus een eerste stap zijn naar het kunnen herbruiken van externe begrippen. Dit wordt nader toegelicht in <a href="#hergebruik">hergebruik</a>.</p>
 <p>Aanbevelingen:</p>
-<div class="practice advisement"><a class="marker self-link" href="#bp-er-kan-worden-verwezen-naar-een-extern-begrip-met-de-harmonisatierelaties-zoals-gedefinieerd-door-skos"><bdi lang="en">Best Practice 10</bdi></a>: <span class="practicelab" id="bp-er-kan-worden-verwezen-naar-een-extern-begrip-met-de-harmonisatierelaties-zoals-gedefinieerd-door-skos">Er kan worden verwezen naar een <a data-link-type="dfn|abstract-op" href="#dfn-extern-begrip" class="internalDFN" id="ref-for-dfn-extern-begrip-1">extern begrip</a> met de harmonisatierelaties zoals gedefinieerd door SKOS.</span><p class="practicedesc">We maken expliciet geen gebruik van owl:sameAs.</p></div>
-
-</section><section id="hergebruik"><div class="header-wrapper"><h4 id="x1-3-2-hergebruik"><bdi class="secno">1.3.2 </bdi>Hergebruik</h4><a class="self-link" href="#hergebruik" aria-label="Permalink for Section 1.3.2"></a></div>
+<div class="practice advisement"><a class="marker self-link" href="#bp-er-kan-worden-verwezen-naar-een-extern-begrip-met-de-harmonisatierelaties-zoals-gedefinieerd-door-skos"><bdi lang="en">Best Practice 10</bdi></a>: <span class="practicelab" id="bp-er-kan-worden-verwezen-naar-een-extern-begrip-met-de-harmonisatierelaties-zoals-gedefinieerd-door-skos">Er kan worden verwezen naar een <a data-link-type="dfn|abstract-op" href="#dfn-extern-begrip" class="internalDFN" id="ref-for-dfn-extern-begrip-1">extern begrip</a> met de harmonisatierelaties zoals gedefinieerd door SKOS.</span><p class="practicedesc">We maken expliciet geen gebruik van owl:sameAs.</p></div></section><section id="hergebruik"><div class="header-wrapper"><h4 id="x1-3-2-hergebruik"><bdi class="secno">1.3.2 </bdi>Hergebruik</h4><a class="self-link" href="#hergebruik" aria-label="Permalink for Section 1.3.2"></a></div>
 <p>Het hergebruiken van begrippen is het opnemen van begrippen in verschillende begrippenkaders. In tegenstelling tot bij harmonisatie, waar twee losse verzamelingen van begrippen aan elkaar gerelateerd worden door extra relaties te leggen, wordt bij hergebruik één begrip aan verschillende begrippenkaders toegevoegd. In deze zin commiteer je volledig aan de beschrijving van het begrip uit een ander begrippenkader. Dit is afgebeeld in het volgende diagram.</p>
 <p>
       </p><figure id="fig-datastructuren-hergebruik-en-harmonisatie">
@@ -707,7 +714,7 @@ ex2:Land a skos:Concept
     <p></p>
 <p>Begrippen komen zo terug in verschillende contexten. Dit is een algemene good-practice omdat we hiermee contexten integreren (waarmee we expliciet dezelfde taal spreken) maar ook omdat we hiermee contexten kunnen modularizeren (conform het Don't Repeat Yourself principe (DRY)).</p>
 <p>SKOS gaat er van uit dat de betekenis van een begrip niet beïnvloed wordt door de statements die er over vastgelegd zijn. De eigenaar van het begrip bepaald namelijk de betekenis. De statements over een begrip maken we om deze inherente betekenis te kunnen communiceren. Eveneens dat een huis niet blauw wordt puur omdat er is geregistreerd dat deze blauw is. Een goede beschrijving zorgt ervoor dat men het begrip juist interpreteert zodat het we begrip op de correcte wijze begrijpen. Wanneer je naar een blauw huis zoekt die in de werkelijkheid helemaal niet blauw is; is het lastig om het betreffende huis te vinden. De betekenis van een begrip is dus niet afhankelijk van de statements die we er over maken, maar de statements verwoorden de betekenis die het begrip al heeft. </p>
-<p>In de praktijk betekent dit dat een begrip in elke context gebruikt kan worden, zonder dat de betekenis zal veranderen. Het toevoegen van eigenschappen is mogelijk, (<a href="https://www.w3.org/TR/2002/WD-rdf-concepts-20020829/#xtocid48014">anyone can say anything about anything</a>); al moet wel beoordeeld worden wat de impact is op de interpretatie van het begrip door mensen. Een begrip wordt onderdeel van een begrippenkader wanneer het een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: not matching `&lt;dfn&gt;`" id="respec-offender-linking-error-not-matching-dfn-9">in kader</a> relatie heeft naar het begrippenkader. Het is niet noodzakelijk om eigenschappen van het externe begrip, zoals de voorkeursterm, te repliceren wanneer het externe begrip gepubliceert is. Een Semantic Web applicatie zal op basis van de URI de beschrijving kunnen ophalen, (dereferencen) of het gehele begrippenkader importeren, bijvoorbeeld op basis van een owl:imports statement. Hierbij komt versiebeheer van begrippen nadrukkelijk om de hoek kijken. Hiervoor is een uitwerking gemaakt in <a href="#begrippenbeheer-en-metadata">hoofdstuk 5.5</a>.</p>
+<p>In de praktijk betekent dit dat een begrip in elke context gebruikt kan worden, zonder dat de betekenis zal veranderen. Het toevoegen van eigenschappen is mogelijk, (<a href="https://www.w3.org/TR/2002/WD-rdf-concepts-20020829/#xtocid48014">anyone can say anything about anything</a>); al moet wel beoordeeld worden wat de impact is op de interpretatie van het begrip door mensen. Een begrip wordt onderdeel van een begrippenkader wanneer het een <a data-link-type="dfn|abstract-op" class="respec-offending-element" title="Linking error: no matching `&lt;dfn&gt;`" id="respec-offender-linking-error-no-matching-dfn-9">in kader</a> relatie heeft naar het begrippenkader. Het is niet noodzakelijk om eigenschappen van het externe begrip, zoals de voorkeursterm, te repliceren wanneer het externe begrip gepubliceert is. Een Semantic Web applicatie zal op basis van de URI de beschrijving kunnen ophalen, (dereferencen) of het gehele begrippenkader importeren, bijvoorbeeld op basis van een owl:imports statement. Hierbij komt versiebeheer van begrippen nadrukkelijk om de hoek kijken. Hiervoor is een uitwerking gemaakt in <a href="#begrippenbeheer-en-metadata">hoofdstuk 5.5</a>.</p>
 <p>Vervolgens kunnen relaties tussen de externe begrippen en de andere begrippen in het begrippenkader gelegd waardoor een netwerk of stelsel ontstaat. In RDF kan dat er als volgt uit zien.</p>
 <div class="example" id="example-7">
         <div class="marker">
@@ -725,17 +732,12 @@ ex2:Land a skos:Concept ;
   skos:prefLabel <span class="hljs-string">"Land"</span>@nl ;
   skos:definition <span class="hljs-string">"Een land is een gebied met grenzen en een eigen regering."</span> ;
   skos:broader ex:BestuurlijkGebied .</code></pre>
-      </div>
-
-<p>Aanbevelingen:</p>
+      </div><p>Aanbevelingen:</p>
 <div class="practice advisement"><a class="marker self-link" href="#bp-statements-over-externe-begrippen-van-de-bronhouder-kunnen-niet-veranderd-worden-je-commiteert-je-namelijk-aan-het-begrip-zoals-het-beschreven-is-door-de-bronhouder"><bdi lang="en">Best Practice 11</bdi></a>: <span class="practicelab" id="bp-statements-over-externe-begrippen-van-de-bronhouder-kunnen-niet-veranderd-worden-je-commiteert-je-namelijk-aan-het-begrip-zoals-het-beschreven-is-door-de-bronhouder">Statements over externe begrippen van de bronhouder kunnen niet veranderd worden, je commiteert je namelijk aan het begrip zoals het beschreven is door de bronhouder.</span><p class="practicedesc">Wanneer een extern begrip wordt toegevoegd aan een begrippenkader kunnen enkel aanvullende statements worden gemaakt. Deze aanvullende statements maak je altijd in de omgeving die je zelf beheert, waarmee het eigenaarschap duidelijk is.</p></div>
 <div class="practice advisement"><a class="marker self-link" href="#bp-het-externe-begrip-is-onderdeel-van-het-lokale-begrippenkader-en-krijgt-dus-een-in-kader-relatie-naar-het-lokale-begrippenkader-en-behoudt-de-in-kader-relatie-naar-het-orginele-begrippenkader"><bdi lang="en">Best Practice 12</bdi></a>: <span class="practicelab" id="bp-het-externe-begrip-is-onderdeel-van-het-lokale-begrippenkader-en-krijgt-dus-een-in-kader-relatie-naar-het-lokale-begrippenkader-en-behoudt-de-in-kader-relatie-naar-het-orginele-begrippenkader">Het externe begrip is onderdeel van het lokale begrippenkader en krijgt dus een 'in kader' relatie naar het lokale begrippenkader en behoudt de 'in kader' relatie naar het orginele begrippenkader.</span><p class="practicedesc"></p></div>
 <div class="practice advisement"><a class="marker self-link" href="#bp-een-extern-begrip-kan-een-plek-krijgen-in-de-hierarchie-van-het-lokale-begrippenkader-aan-de-hand-van-heeft-bovenliggend-begrip-relaties-van-en-naar-het-externe-begrip"><bdi lang="en">Best Practice 13</bdi></a>: <span class="practicelab" id="bp-een-extern-begrip-kan-een-plek-krijgen-in-de-hierarchie-van-het-lokale-begrippenkader-aan-de-hand-van-heeft-bovenliggend-begrip-relaties-van-en-naar-het-externe-begrip">Een extern begrip kan een plek krijgen in de hierarchie van het lokale begrippenkader aan de hand van 'heeft bovenliggend begrip' relaties van en naar het externe begrip.</span><p class="practicedesc"></p></div>
 <div class="practice advisement"><a class="marker self-link" href="#bp-een-extern-begrip-kan-een-startpunt-zijn-in-een-hierarchie-van-begrippen-en-zo-dus-een-heeft-topbegrip-relatie-of-inverse-daarvan-kennen"><bdi lang="en">Best Practice 14</bdi></a>: <span class="practicelab" id="bp-een-extern-begrip-kan-een-startpunt-zijn-in-een-hierarchie-van-begrippen-en-zo-dus-een-heeft-topbegrip-relatie-of-inverse-daarvan-kennen">Een extern begrip kan een startpunt zijn in een hierarchie van begrippen, en zo dus een 'heeft topbegrip' relatie (of inverse daarvan) kennen.</span><p class="practicedesc"></p></div>
-<div class="practice advisement"><a class="marker self-link" href="#bp-wanneer-het-externe-begrip-is-gepubliceerd-is-het-niet-noodzakelijk-om-de-beschrijving-te-repliceren-dit-kan-opgehaald-worden-aan-de-hand-van-de-uri-van-het-begrip"><bdi lang="en">Best Practice 15</bdi></a>: <span class="practicelab" id="bp-wanneer-het-externe-begrip-is-gepubliceerd-is-het-niet-noodzakelijk-om-de-beschrijving-te-repliceren-dit-kan-opgehaald-worden-aan-de-hand-van-de-uri-van-het-begrip">Wanneer het externe begrip is gepubliceerd, is het niet noodzakelijk om de beschrijving te repliceren. Dit kan opgehaald worden aan de hand van de URI van het begrip.</span><p class="practicedesc"></p></div>
-
-
-</section></section><section id="samenwerking-informatiemodel-en-begrippenkader"><div class="header-wrapper"><h3 id="x1-4-samenwerking-informatiemodel-en-begrippenkader"><bdi class="secno">1.4 </bdi>Samenwerking Informatiemodel en Begrippenkader</h3><a class="self-link" href="#samenwerking-informatiemodel-en-begrippenkader" aria-label="Permalink for Section 1.4"></a></div>
+<div class="practice advisement"><a class="marker self-link" href="#bp-wanneer-het-externe-begrip-is-gepubliceerd-is-het-niet-noodzakelijk-om-de-beschrijving-te-repliceren-dit-kan-opgehaald-worden-aan-de-hand-van-de-uri-van-het-begrip"><bdi lang="en">Best Practice 15</bdi></a>: <span class="practicelab" id="bp-wanneer-het-externe-begrip-is-gepubliceerd-is-het-niet-noodzakelijk-om-de-beschrijving-te-repliceren-dit-kan-opgehaald-worden-aan-de-hand-van-de-uri-van-het-begrip">Wanneer het externe begrip is gepubliceerd, is het niet noodzakelijk om de beschrijving te repliceren. Dit kan opgehaald worden aan de hand van de URI van het begrip.</span><p class="practicedesc"></p></div></section></section><section id="samenwerking-informatiemodel-en-begrippenkader"><div class="header-wrapper"><h3 id="x1-4-samenwerking-informatiemodel-en-begrippenkader"><bdi class="secno">1.4 </bdi>Samenwerking Informatiemodel en Begrippenkader</h3><a class="self-link" href="#samenwerking-informatiemodel-en-begrippenkader" aria-label="Permalink for Section 1.4"></a></div>
 <p>Ergens ligt een knip tussen een samenhangende beschrijving van begrippen in een begrippenkader en een model van klassen in een ontologie. Wikipedia definieert een ontologie (van het Grieks ὀν = zijnde en λόγος = woord, leer) of zijnsleer als de filosofische tak die het wezen onderzoekt dat achter de waargenomen werkelijkheid schuilgaat. De ontologie onderzoekt en beschrijft de eigenschappen, of breder: het zijn van het geheel van dingen, entiteiten of zijnden waarvan aangenomen wordt dat ze bestaan of beter: zijn. De ontologie gaat dus over de dingen zelf, hun 'zijn', terwijl begrippen gaat over de 'gedachte'. In de praktijk is het wel handig als deze twee op elkaar aansluiten. In de psychiatrie zijn voldoende voorbeelden waar de 'gedachte' over de wereld niet matcht met de wereld zelf. Dit wordt ook weerspiegeld in uitdrukkingen als 'met beide benen op de grond staan' (conceptualisering duidelijk verbonden met de fysieke werkelijkheid, de grond) en 'met het hoofd in de wolken lopen'(conceptualisering duidelijk los van de fysieke werkelijkheid, c.q. de grond).</p>
 <ul>
 <li>Dit komt bij elkaar in het idee van een "begrip" naast een "klasse" uit de ontologie: de werkelijkheid laat zich moeilijk vangen, maar we kunnen wel met elkaar afspreken hoe we tegen de werkelijkheid aan moeten willen kijken. Dit noemen we "ontological commitment": we commiteren ons aan de ontologie, die klassen beschrijft waarvan de betekenis is gevangen in de begrippen. Het is de werkelijkheid zoals we met elkaar afgesproken dat deze "waar" is.<ul>
@@ -851,13 +853,13 @@ Een belangrijk aspect voor een stelsel is het in een tijdcontext kunnen relatere
 <li>Dataset = <code>dcat:Dataset</code>.</li>
 </ul>
 <section id="begrippenkader-als-dataset"><div class="header-wrapper"><h6 id="x1-5-4-1-1-begrippenkader-als-dataset"><bdi class="secno">1.5.4.1.1 </bdi>Begrippenkader als dataset</h6><a class="self-link" href="#begrippenkader-als-dataset" aria-label="Permalink for Section 1.5.4.1.1"></a></div>
-<p>Een object is beschreven in een gegevensobject en dit gegevensobject is onderdeel van een dataset. Dat is het patroon wat gehanteerd wordt voor het versiebeheer van begrippen(kaders).</p>
-<p>Cognitief maken mensen niet altijd een onderscheid tussen het ding-als-concept (“begrip”, “begrippenkader”, “taxonomie”, “lijstje”) en het ding-als-informatieobject (waar dan dezelfde woorden worden gebruikt). Als dit onderscheid minder belangrijk is kan er gekozen worden om dat onderscheid niet te maken. We volgen dan een ander patroon voor versiebeheer. Technisch gezien leidt dit patroon tot punning. Het begrippenkader bevat begrippen én begripsbeschrijvingen. Dit maakt het begrippenkader zowel een 'conceptueel object' als een 'informatieobject'. Dit is een variatie op Variant B waarbij het begrippenkader én de begrippenkaderbeschrijving én de beheereenheid (of publicatieeenheid) dezelfde identiteit hebben.</p>
-<p>Indien een begrippenkader dus ook beoogd is als de dataset, dan geldt bovendien <em>ook</em> nog de taalbinding:</p>
+<p>In de paragraaf hierboven is onderscheid gemaakt tussen begrippenkader en dataset. Als dit onderscheid minder belangrijk is kan er gekozen worden om dat onderscheid niet te maken. Indien een begrippenkader ook beoogd is als de dataset, dan geldt de taalbinding:</p>
 <ul>
 <li>Begrippenkader = <code>skos:ConceptScheme</code> EN <code>dcat:Dataset</code></li>
 </ul>
-<p>Het term "Begrippenkader" en synoniemen als "Taxonomie", "Thesaurus" of "Begrippenstelsel" zijn daarmee zowel bruikbaar voor situaties waarbij een abstracte verzameling van begrippen wordt bedoeld (via <code>skos:inScheme</code>) en voor situaties waar bij een verzameling van beschrijvingen van dergelijke begrippen wordt bedoeld (via <code>dcat:Dataset</code>). Alleen als in de taalbinding beide aanwezig zijn, is sprake van <em>punning</em> en wordt zowel een abstracte verzameling van begrippen bedoeld als een verzameling van beschrijvingen. Dit is een ruime opvatting van de definitie van begrippenkader maar dit wordt niet uitgesloten in SBB.</p>
+<p>In het algemeen kun je stellen dat een object wordt beschreven in een gegevensobject en dit gegevensobject is onderdeel van een dataset. Dat is ook het patroon dat gehanteerd wordt voor het versiebeheer van begrippen(kaders).</p>
+<p>Cognitief maken mensen niet altijd een onderscheid tussen het ding-als-concept (“begrip”, “begrippenkader”, “taxonomie”, “lijstje”) en het ding-als-gegevensobject (waar dan dezelfde woorden worden gebruikt). We volgen dan een ander patroon voor versiebeheer. Het begrippenkader bevat begrippen én begripsbeschrijvingen. Dit maakt het begrippenkader zowel een 'conceptueel object' als een 'informatieobject'. Dit is een variatie op Variant B waarbij het begrippenkader én de begrippenkaderbeschrijving én de beheereenheid (of publicatieeenheid) dezelfde identiteit hebben.</p>
+<p>Het term "Begrippenkader" en synoniemen als "Taxonomie", "Thesaurus" of "Begrippenstelsel" zijn daarmee zowel bruikbaar voor situaties waarbij een abstracte verzameling van begrippen wordt bedoeld (via <code>skos:inScheme</code>) en voor situaties waar bij een verzameling van beschrijvingen van dergelijke begrippen wordt bedoeld (via <code>dcat:Dataset</code>). Alleen als in de taalbinding beide aanwezig zijn, wordt zowel een abstracte verzameling van begrippen bedoeld als een verzameling van beschrijvingen. Dit is een ruime opvatting van de definitie van begrippenkader maar dit wordt niet uitgesloten in SBB.</p>
 <blockquote>
 <p>Advies is om expliciet aan te geven bij de beschrijving van een begrippenkader of ook sprake is van een eenheid van beheer, publicatie of herkomst.</p>
 </blockquote>
@@ -872,14 +874,14 @@ Een belangrijk aspect voor een stelsel is het in een tijdcontext kunnen relatere
 </section><section id="voorbeelduitwerkingen"><div class="header-wrapper"><h5 id="x1-5-4-3-voorbeelduitwerkingen"><bdi class="secno">1.5.4.3 </bdi>Voorbeelduitwerkingen</h5><a class="self-link" href="#voorbeelduitwerkingen" aria-label="Permalink for Section 1.5.4.3"></a></div>
 <p>Voor de drie gedefinieerde variaties geven we een voorbeelduitwerking:</p>
 <ul>
-<li><a href="./sessies/metadata/versiebeheer/voorbeelduitwerkingen/VariantA.ttl">Variant A</a> De begripsbeschrijving is de eenheid van beheer</li>
-<li><a href="./sessies/metadata/versiebeheer/voorbeelduitwerkingen/variantB.ttl">Variant B</a> Het begrippenkader komt overeen met de eenheid van beheer</li>
-<li><a href="./sessies/metadata/versiebeheer/voorbeelduitwerkingen/VariantC.trig">Variant C</a> Een deel van een complete begripsbeschrijving als eenheid van beheer</li>
+<li><a href="voorbeelduitwerkingen/VariantA.ttl">Variant A</a> De begripsbeschrijving is de eenheid van beheer</li>
+<li><a href="voorbeelduitwerkingen/variantB.ttl">Variant B</a> Het begrippenkader komt overeen met de eenheid van beheer</li>
+<li><a href="voorbeelduitwerkingen/VariantC.trig">Variant C</a> Een deel van een complete begripsbeschrijving als eenheid van beheer</li>
 </ul>
 <p>Aanvullend geven we twee extra uitwerkingen:</p>
 <ul>
-<li><a href="./sessies/metadata/versiebeheer/voorbeelduitwerkingen/VariantB1.ttl">Variant B.1</a> Het begrippenkader is óók de eenheid van beheer</li>
-<li><a href="./sessies/metadata/versiebeheer/voorbeelduitwerkingen/VariantB2.ttl">Variant B.2</a> De beheereenheid is een verzameling begripsbeschrijvingen die niet overeenkomt met het begrippenkader</li>
+<li><a href="voorbeelduitwerkingen/VariantB1.ttl">Variant B.1</a> Het begrippenkader is óók de eenheid van beheer</li>
+<li><a href="voorbeelduitwerkingen/VariantB2.ttl">Variant B.2</a> De beheereenheid is een verzameling begripsbeschrijvingen die niet overeenkomt met het begrippenkader</li>
 </ul>
 </section></section></section></section>
   <section class="informative" id="over-het-adopteren-van-nl-sbb-en-het-verbinden-met-skos-begrippen"><div class="header-wrapper"><h2 id="x2-over-het-adopteren-van-nl-sbb-en-het-verbinden-met-skos-begrippen"><bdi class="secno">2. </bdi>Over het adopteren van NL-SBB en het verbinden met SKOS begrippen</h2><a class="self-link" href="#over-het-adopteren-van-nl-sbb-en-het-verbinden-met-skos-begrippen" aria-label="Permalink for Section 2."></a></div><p><em>Dit onderdeel is niet-normatief.</em></p>
@@ -1427,16 +1429,16 @@ Door begrippen te typeren als act (rechtshandeling), actor (uitvoerder van die h
 <section id="references" class="appendix"><div class="header-wrapper"><h2 id="b-referenties"><bdi class="secno">B. </bdi>Referenties</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix B."></a></div><section id="normatieve-referenties">
     <div class="header-wrapper"><h3 id="b-1-normatieve-referenties"><bdi class="secno">B.1 </bdi>Normatieve referenties</h3><a class="self-link" href="#normatieve-referenties" aria-label="Permalink for Appendix B.1"></a></div>
     <dl class="bibliography"><dt id="bib-rfc2119">[RFC2119]</dt><dd>
-      <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
+      <a href="https://www.rfc-editor.org/info/rfc2119/"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/info/rfc2119/">https://www.rfc-editor.org/info/rfc2119/</a>
     </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
-      <a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a>
+      <a href="https://www.rfc-editor.org/info/rfc8174/"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/info/rfc8174/">https://www.rfc-editor.org/info/rfc8174/</a>
     </dd></dl>
   </section><section id="informatieve-referenties">
     <div class="header-wrapper"><h3 id="b-2-informatieve-referenties"><bdi class="secno">B.2 </bdi>Informatieve referenties</h3><a class="self-link" href="#informatieve-referenties" aria-label="Permalink for Appendix B.2"></a></div>
     <dl class="bibliography"><dt id="bib-dcterms">[DCTERMS]</dt><dd>
       <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/"><cite>DCMI Metadata Terms</cite></a>. DCMI Usage Board.  DCMI. 20 January 2020. DCMI Recommendation. URL: <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/">https://www.dublincore.org/specifications/dublin-core/dcmi-terms/</a>
     </dd><dt id="bib-foaf">[FOAF]</dt><dd>
-      <a href="http://xmlns.com/foaf/spec"><cite>FOAF Vocabulary Specification 0.99 (Paddington Edition)</cite></a>. Dan Brickley; Libby Miller.  FOAF project. 14 January 2014. URL: <a href="http://xmlns.com/foaf/spec">http://xmlns.com/foaf/spec</a>
+      <a href="http://xmlns.com/foaf/spec/"><cite>FOAF Vocabulary Specification 0.99 (Paddington Edition)</cite></a>. Dan Brickley; Libby Miller.  FOAF project. 14 January 2014. URL: <a href="http://xmlns.com/foaf/spec/">http://xmlns.com/foaf/spec/</a>
     </dd><dt id="bib-nlsbb">[NLSBB]</dt><dd>
       <a href="https://docs.geostandaarden.nl/nl-sbb/nl-sbb/"><cite>NL-SBB - Standaard voor het beschrijven van begrippen</cite></a>. Jesse Bakker; Arjen Santema; Kees Trautwein.  Geonovum. URL: <a href="https://docs.geostandaarden.nl/nl-sbb/nl-sbb/">https://docs.geostandaarden.nl/nl-sbb/nl-sbb/</a>
     </dd><dt id="bib-skos-reference">[SKOS-REFERENCE]</dt><dd>
@@ -1453,6 +1455,7 @@ Door begrippen te typeren als act (rechtshandeling), actor (uitvoerder van die h
       <div>
         <a class="self-link" href="#dfn-polyhierarchy" aria-label="Permalink for definition: polyhierarchy. Activate to close this dialog.">Permalink</a>
          
+        
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -1465,6 +1468,7 @@ Door begrippen te typeren als act (rechtshandeling), actor (uitvoerder van die h
       <div>
         <a class="self-link" href="#dfn-extern-begrip" aria-label="Permalink for definition: extern begrip. Activate to close this dialog.">Permalink</a>
          
+        
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
@@ -1487,8 +1491,11 @@ function setupPanel() {
 }
 
 function panelListener() {
-  /** @type {HTMLElement} */
+  /** @type {HTMLElement | null} */
   let panel = null;
+  /**
+   * @param {KeyboardEvent|MouseEvent} event
+   */
   return event => {
     const { target, type } = event;
 
@@ -1496,24 +1503,34 @@ function panelListener() {
 
     // For keys, we only care about Enter key to activate the panel
     // otherwise it's activated via a click.
-    if (type === "keydown" && event.key !== "Enter") return;
+    if (
+      type === "keydown" &&
+      /** @type {KeyboardEvent} */ (event).key !== "Enter"
+    )
+      return;
 
     const action = deriveAction(event);
 
     switch (action) {
       case "show": {
         hidePanel(panel);
-        /** @type {HTMLElement} */
+        /** @type {HTMLElement | null} */
         const dfn = target.closest("dfn, .index-term");
+        if (!dfn?.id) break;
         panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
-        const coords = deriveCoordinates(event);
+        if (!panel) break;
+        const coords = deriveCoordinates(
+          /** @type {MouseEvent|KeyboardEvent} */ (event)
+        );
         displayPanel(dfn, panel, coords);
         break;
       }
       case "dock": {
-        panel.style.left = null;
-        panel.style.top = null;
-        panel.classList.add("docked");
+        if (panel) {
+          panel.style.left = "";
+          panel.style.top = "";
+          panel.classList.add("docked");
+        }
         break;
       }
       case "hide": {
@@ -1564,7 +1581,8 @@ function deriveAction(event) {
     if (hitALink) {
       return target.classList.contains("self-link") ? "hide" : "dock";
     }
-    const panel = target.closest(".dfn-panel");
+
+    const panel = /** @type {HTMLElement} */ (target.closest(".dfn-panel"));
     return panel.classList.contains("docked") ? "hide" : "none";
   }
   if (document.querySelector(".dfn-panel:not([hidden])")) {
@@ -1608,9 +1626,9 @@ function displayPanel(dfn, panel, { x, y }) {
     const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
     const newCaretOffset = left - newLeft;
     panel.style.left = `${newLeft}px`;
-    /** @type {HTMLElement} */
+    /** @type {HTMLElement | null} */
     const caret = panel.querySelector(".caret");
-    caret.style.left = `${newCaretOffset}px`;
+    if (caret) caret.style.left = `${newCaretOffset}px`;
   }
 
   // As it's a dialog, we trap focus.
@@ -1659,6 +1677,9 @@ function trapFocus(panel, dfn) {
 function createTrapListener(anchors, panel, dfn) {
   const lastIndex = anchors.length - 1;
   let currentIndex = 0;
+  /**
+   * @param {KeyboardEvent} event
+   */
   return event => {
     switch (event.key) {
       // Hitting "Tab" traps us in a nice loop around elements.
@@ -1688,7 +1709,7 @@ function createTrapListener(anchors, panel, dfn) {
   };
 }
 
-/** @param {HTMLElement} panel */
+/** @param {HTMLElement | null} panel */
 function hidePanel(panel) {
   if (!panel) return;
   panel.hidden = true;

--- a/voorbeelduitwerkingen/VariantA.ttl
+++ b/voorbeelduitwerkingen/VariantA.ttl
@@ -1,0 +1,27 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# Begrip
+<http://nlbegrip.nl/synthesizer/id/begrip/vco> a skos:Concept;
+    rdfs:label "VCO"@nl;
+    skos:prefLabel "VCO"@nl;
+    skos:altLabel "Voltage Controlled Oscillator"@en;
+    skos:definition "Een VCO is een electronische geluidsbron waarbij de frequency van het geluid wordt gecontroleerd met een electrische spanning (voltage)"@nl;
+    rdfs:isDefinedBy <http://nlbegrip.nl/doc/begrip/vco/1.0.0-snapshot-1>;
+.
+# Begripsbeschrijving, Beheereenheid, provenance eenheid
+<http://nlbegrip.nl/synthesizer/doc/begrip/vco> a dcat:Dataset, prov:Entity;
+    rdfs:label "Beschrijving van het begrip «VCO»";
+    rdfs:comment "Deze beschrijving is zowel een begripsbeschrijving, een beheereenheid als de vindplek van de meest actuele versie van deze begripsbeschrijving";
+    foaf:primaryTopic <http://nlbegrip.nl/synthesizer/id/begrip/vco>;
+.
+# Begripsbeschrijving versie
+<http://nlbegrip.nl/doc/begrip/vco/1.0.0-snapshot-1> a dcat:Dataset;
+    rdfs:label "Versie 1.0.0 snapshot 1 van de beschrijving van het begrip «VCO»";
+    dct:isVersionOf <http://nlbegrip.nl/synthesizer/doc/begrip/vco>;
+.

--- a/voorbeelduitwerkingen/VariantB1.ttl
+++ b/voorbeelduitwerkingen/VariantB1.ttl
@@ -1,0 +1,50 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# Begrippenkader, Begrippenkaderbeschrijving, Beheereenheid
+<http://nlbegrip.nl/synthesizer#> a skos:ConceptScheme, dcat:Dataset;
+    rdfs:label "Synthesizer begrippen";
+    rdfs:comment "Dit begrippenkader is ook een beheereenheid en de vindplek van de meest actuele versie";
+    owl:versionInfo "Versie 1.0.0 snapshot 1";
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer>;
+.
+
+# Begrippenkaderbeschrijving versie, Beheereenheid versie
+<http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1> a dcat:Dataset;
+    rdfs:label "Versie 1.0.0 snapshot 1 van het begrippenkader voor synthesizers";
+    dct:isVersionOf <http://nlbegrip.nl/synthesizer#>;
+.
+# Begrip
+<http://nlbegrip.nl/synthesizer/id/begrip/synthesizer> a skos:Concept;
+    rdfs:label "Synthesizer"@nl;
+    skos:prefLabel "Synthesizer"@nl;
+    skos:definition "Een synthesizer is een elektronisch muziekinstrument dat klanken en geluiden kunstmatig opwekt."@nl;
+    skos:inScheme <http://nlbegrip.nl/synthesizer#>;
+    dct:source <https://nl.wikipedia.org/wiki/Synthesizer>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1>;
+.
+# Begripsbeschrijving, provenance eenheid
+<http://nlbegrip.nl/synthesizer/doc/begrip/synthesizer> a prov:Entity;
+    rdfs:label "Beschrijving van het begrip «Synthesizer»";
+    foaf:primaryTopic <http://nlbegrip.nl/synthesizer/id/begrip/synthesizer>;
+    rdfs:comment "Deze beschrijving betreft de beschrijving van het begrip";
+.
+# Begrip
+<http://nlbegrip.nl/synthesizer/id/begrip/vco> a skos:Concept;
+    rdfs:label "VCO"@nl;
+    skos:prefLabel "VCO"@nl;
+    skos:altLabel "Voltage Controlled Oscillator"@en;
+    skos:definition "Een VCO is een electronische geluidsbron waarbij de frequency van het geluid wordt gecontroleerd met een electrische spanning (voltage)"@nl;
+    foaf:primaryTopic <http://nlbegrip.nl/synthesizer/id/begrip/vco>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1>;
+.
+# Begripsbeschrijving, provenance eenheid
+<http://nlbegrip.nl/synthesizer/doc/begrip/vco> a prov:Entity;
+    rdfs:label "Beschrijving van het begrip «VCO»";
+    rdfs:comment "Deze beschrijving betreft de beschrijving van het begrip";
+.

--- a/voorbeelduitwerkingen/VariantB2.ttl
+++ b/voorbeelduitwerkingen/VariantB2.ttl
@@ -1,0 +1,106 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# Beheereenheid, provenance eenheid
+<http://nlbegrip.nl/synthesizer-basis> a dcat:Dataset, prov:Entity;
+    rdfs:label "Synthesizer basis"@nl;
+    rdfs:comment "Deze dataset bevat de beschrijvingen van de begrippen(kaders), collecties en bronnen binnen de context van Begrippenkader Synthesizer";
+    owl:versionInfo "Versie 1.0.0 snapshot 1";
+.
+# Beheereenheid versie, provenance eenheid versie
+<http://nlbegrip.nl/synthesizer-basis/1.0.0-snapshot-1> a dcat:Dataset, prov:Entity;
+    rdfs:label "Versie 1.0.0 snapshot 1 van synthesizer basis"@nl;
+    dct:isVersionOf <http://nlbegrip.nl/synthesizer-basis>;
+    foaf:topic
+      <http://nlbegrip.nl/synthesizer/id/begrippenkader/synthesizer>,
+      <http://nlbegrip.nl/synthesizer/id/begrip/synthesizer>,
+      <http://nlbegrip.nl/synthesizer/id/begrip/synthese>,
+      <http://nlbegrip.nl/synthesizer/id/begrip/vco>;
+.
+# Begrippenkader
+<http://nlbegrip.nl/synthesizer/id/begrippenkader/synthesizer> a skos:ConceptScheme;
+    rdfs:label "Syntesizer begrippen"@nl;
+    rdfs:comment "Dit begrippenkader is een verzameling van begrippen die in de context van synthesizers relevant zijn."@nl;
+    skos:hasTopConcept 
+      <http://nlbegrip.nl/synthesizer/id/begrip/synthese> ,
+      <http://nlbegrip.nl/synthesizer/id/begrip/synthesizer> ,
+      <http://nlbegrip.nl/synthesizer/id/begrip/vco>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer-basis/1.0.0-snapshot-1>;
+.
+# Begrip
+<http://nlbegrip.nl/synthesizer/id/begrip/synthesizer> a skos:Concept;
+    rdfs:label "Synthesizer"@nl;
+    skos:prefLabel "Synthesizer"@nl;
+    skos:definition "Een synthesizer is een elektronisch muziekinstrument dat klanken en geluiden kunstmatig opwekt."@nl;
+    skos:related <http://nlbegrip.nl/synthesizer/id/begrip/synthese>;
+    skos:inScheme <http://nlbegrip.nl/synthesizer/id/begrippenkader/synthesizer>;
+    dct:source <https://nl.wikipedia.org/wiki/Synthesizer>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer-basis/1.0.0-snapshot-1>;
+.  
+# Begrip
+<http://nlbegrip.nl/synthesizer/id/begrip/synthese> a skos:Concept;
+    rdfs:label "Synthese"@nl;
+    skos:prefLabel "Synthese"@nl;
+    skos:definition "Het kunstmatig opwekken van klanken en geluiden."@nl;
+    skos:inScheme <http://nlbegrip.nl/synthesizer/id/begrippenkader/synthesizer>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer-basis/1.0.0-snapshot-1>;
+.
+# Begrip
+<http://nlbegrip.nl/synthesizer/id/begrip/vco> a skos:Concept;
+    rdfs:label "VCO"@nl;
+    skos:prefLabel "VCO"@nl;
+    skos:altLabel "Voltage Controlled Oscillator"@en;
+    skos:definition "Een VCO is een electronische geluidsbron waarbij de frequency van het geluid wordt gecontroleerd met een electrische spanning (voltage)"@nl;
+    skos:inScheme <http://nlbegrip.nl/synthesizer/id/begrippenkader/synthesizer>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer-basis/1.0.0-snapshot-1>;
+.
+# Beheereenheid, provenance eenheid
+<http://nlbegrip.nl/synthesizer-synthese> a dcat:Dataset, prov:Entity;
+    rdfs:label "Synthese begrippen"@nl;
+    rdfs:comment "Deze dataset bevat beschrijvingen van begrippen over modulatie; voortbouwend op het begrippenkader Synthesizer"@nl;
+    owl:versionInfo "Versie 1.0.0 snapshot 1";
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer-synthese>;
+.
+# Beheereenheid versie, provenance eenheid versie
+<http://nlbegrip.nl/synthesizer-synthese/1.0.0-snapshot-1> a dcat:Dataset, prov:Entity;
+    rdfs:label "Versie 1.0.0 snapshot 1 van synthesizer-synthese beschrijvingen"@nl;
+    dct:isVersionOf <http://nlbegrip.nl/synthesizer-synthese>;
+    owl:imports <http://nlbegrip.nl/synthesizer-basis/1.0.0-snapshot-1>;
+    foaf:topic 
+      <http://nlbegrip.nl/synthesizer-synthese/id/begrip/granulaire-synthese>,
+      <http://nlbegrip.nl/synthesizer-synthese/id/begrip/subharmonische-synthese>,
+      <http://nlbegrip.nl/synthesizer-synthese/id/begrip/fm-synthese>;
+.
+# Begrip
+<http://nlbegrip.nl/synthesizer-synthese/id/begrip/granulaire-synthese> a skos:Concept;
+    rdfs:label "Granulaire Synthese"@nl;
+    skos:prefLabel "Granulaire Synthese"@nl;
+    skos:definition "Een techniek waarbij een geluidsfragment, ook wel sample, wordt opgedeeld in zeer korte fragmenten, om daarna te worden herschikt voor het verkrijgen van nieuwe klanken."@nl;
+    skos:broader <http://nlbegrip.nl/synthesizer/id/begrip/synthese>;
+    skos:inScheme <http://nlbegrip.nl/synthesizer/id/begrippenkader/synthesizer>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer-synthese/1.0.0-snapshot-1>;
+.
+# Begrip
+<http://nlbegrip.nl/synthesizer-synthese/id/begrip/subharmonische-synthese> a skos:Concept;
+    rdfs:label "Subharmonische Synthese"@nl;
+    skos:prefLabel "Subharmonische Synthese"@nl;
+    skos:definition "Een techniek waarbij de frequentie van een geluid wordt verdeeld in subharmonische componenten, wat resulteert in diepe, rijke klanken."@nl;
+    skos:broader <http://nlbegrip.nl/synthesizer/id/begrip/synthese>;
+    skos:inScheme <http://nlbegrip.nl/synthesizer/id/begrippenkader/synthesizer>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer-synthese/1.0.0-snapshot-1>;
+.
+# Begrip
+<http://nlbegrip.nl/synthesizer-synthese/id/begrip/fm-synthese> a skos:Concept;
+    rdfs:label "M-synthese (Frequentie Modulatie)"@nl;
+    skos:prefLabel "FM-synthese"@nl;
+    skos:altLabel "Frequentie modulatie"@nl;
+    skos:definition "Een techniek waarbij de frequentie van een draaggolfgolf wordt gemoduleerd door een modulerende golf. Dit leidt tot complexe, bell-achtige klanken."@nl;
+    skos:broader <http://nlbegrip.nl/synthesizer/id/begrip/synthese>;
+    skos:inScheme <http://nlbegrip.nl/synthesizer/id/begrippenkader/synthesizer>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer-synthese/1.0.0-snapshot-1>;
+.

--- a/voorbeelduitwerkingen/VariantC.trig
+++ b/voorbeelduitwerkingen/VariantC.trig
@@ -1,0 +1,51 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+<http://nlbegrip.nl/lex/doc/begrip/vco/1.0.0-snapshot-1> {
+    # Begrip
+    <http://nlbegrip.nl/synthesizer/id/begrip/vco> a skos:Concept;
+        rdfs:label "VCO"@nl;
+        skos:prefLabel "VCO"@nl;
+        skos:altLabel "Voltage Controlled Oscillator"@en;
+        skos:definition "Een VCO is een electronische geluidsbron waarbij de frequency van het geluid wordt gecontroleerd met een electrische spanning (voltage)"@nl;
+        rdfs:isDefinedBy <http://nlbegrip.nl/doc/begrip/vco/1.0.0-snapshot-1>;
+    .
+    # Begripsbeschrijvingdeel, Beheereenheid, provenance eenheid
+    <http://nlbegrip.nl/synthesizer/doc/begrip/vco> a dcat:Dataset, prov:Entity;
+        rdfs:label "Deelbeschrijving van het begrip «VCO» ";
+        rdfs:comment "Deze beschrijving is zowel een begripsbeschrijving deel, een beheereenheid als de vindplek van de meest actuele versie van deze begripsbeschrijving deel";
+        foaf:primaryTopic <http://nlbegrip.nl/synthesizer/id/begrip/vco>;
+    .
+    # Begripsbeschrijvingdeel versie
+    <http://nlbegrip.nl/doc/begrip/vco/1.0.0-snapshot-1> a dcat:Dataset;
+        rdfs:label "Versie 1.0.0 snapshot 1 van de Lexicale beschrijving van het begrip «VCO»";
+        dct:isVersionOf <http://nlbegrip.nl/synthesizer/doc/begrip/vco>;
+    .
+}
+<http://nlbegrip.nl/search/doc/begrip/vco/1.0.0-snapshot-1> {
+    # Begrip
+    <http://nlbegrip.nl/synthesizer/id/begrip/vco> a skos:Concept;
+        rdfs:label "VCO"@nl;
+        skos:hiddenlabel
+        "Voltage Oscillator",
+        "Controlled Oscillator",
+        "Electronic Signal Oscillator";
+        rdfs:isDefinedBy <http://nlbegrip.nl/lex/doc/begrip/vco/1.0.0-snapshot-1>;
+    .
+    # Begripsbeschrijvingdeel, Beheereenheid, provenance eenheid
+    <http://nlbegrip.nl/synthesizer/doc/begrip/vco> a dcat:Dataset, prov:Entity;
+        rdfs:label "Deelbeschrijving van het begrip «VCO» ";
+        rdfs:comment "Deze beschrijving is zowel een begripsbeschrijving deel, een beheereenheid als de vindplek van de meest actuele versie van deze begripsbeschrijving deel";
+        foaf:primaryTopic <http://nlbegrip.nl/synthesizer/id/begrip/vco>;
+    .
+    # Begripsbeschrijvingdeel versie
+    <http://nlbegrip.nl/doc/begrip/vco/1.0.0-snapshot-1> a dcat:Dataset;
+        rdfs:label "Versie 1.0.0 snapshot 1 van de Lexicale beschrijving van het begrip «VCO»";
+        dct:isVersionOf <http://nlbegrip.nl/synthesizer/doc/begrip/vco>;
+    .
+}

--- a/voorbeelduitwerkingen/variantB.ttl
+++ b/voorbeelduitwerkingen/variantB.ttl
@@ -1,0 +1,62 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# Beheereenheid
+<http://nlbegrip.nl/synthesizer> a dcat:Dataset;
+    rdfs:label "De beheereenheid voor begrippenkader synthesizer begrippen en vindplaats van de laatste versie van beschrijvingen die onderdeel zijn van deze beheereenheid.";
+    dct:isVersionOf <http://nlbegrip.nl/syntheziser/doc/begrippenkader/synthesizer>;
+.
+# Beheereenheid versie
+<http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1> a dcat:Dataset;
+    rdfs:label "Versie 1.0.0 snapshot 1 van de beheereenheid voor begrippenkader synthesizer begrippen";
+    dct:isVersionOf <http://nlbegrip.nl/synthesize>;
+.
+# Begrippenkader
+<http://nlbegrip.nl/syntheziser/id/begrippenkader/synthesizer> a skos:ConceptScheme ;
+    rdfs:label "Synthesizer begrippen";
+    rdfs:comment "Dit is het begrippenkader als conceptuele bundeling van begrippen.";
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1>;
+.
+# Begrippenkader beschrijving, provenance eenheid
+<http://nlbegrip.nl/syntheziser/doc/begrippenkader/synthesizer> a prov:Entity ;
+    rdfs:label "Beschrijving van het begrippenkader";
+    rdfs:comment "Deze beschrijving is zowel een begrippenkaderbeschrijving, vindplek van de meest actuele versie van deze begrippenkaderbeschrijving";
+    foaf:primaryTopic <http://nlbegrip.nl/syntheziser/id/begrippenkader/synthesizer>;
+    dct:isPartOf <http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1>
+.
+# Begrip
+<http://nlbegrip.nl/synthesizer/id/begrip/synthesizer> a skos:Concept;
+    rdfs:label "Synthesizer"@nl;
+    skos:prefLabel "Synthesizer"@nl;
+    skos:definition "Een synthesizer is een elektronisch muziekinstrument dat klanken en geluiden kunstmatig opwekt."@nl;
+    skos:inScheme <http://nlbegrip.nl/syntheziser/id/begrippenkader/synthesizer>;
+    dct:source <https://nl.wikipedia.org/wiki/Synthesizer>;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1>
+.
+# Begripsbeschijving, provenance eenheid
+<http://nlbegrip.nl/synthesizer/doc/begrip/synthesizer> a prov:Entity;
+    rdfs:label "Beschrijving van het begrip «Synthesizer»";
+    foaf:primaryTopic <http://nlbegrip.nl/synthesizer/id/begrip/synthesizer>;
+    rdfs:comment "Deze beschrijving betreft de beschrijving van het begrip";
+    dct:isPartOf <http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1>
+.
+# Begrip
+<http://nlbegrip.nl/synthesizer/id/begrip/vco> a skos:Concept;
+    rdfs:label "VCO"@nl;
+    skos:prefLabel "VCO"@nl;
+    skos:altLabel "Voltage Controlled Oscillator"@en;
+    skos:definition "Een VCO is een electronische geluidsbron waarbij de frequency van het geluid wordt gecontroleerd met een electrische spanning (voltage)"@nl;
+    rdfs:isDefinedBy <http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1>;
+.
+# Begripsbeschrijving, provenance eenheid
+<http://nlbegrip.nl/synthesizer/doc/begrip/vco> a prov:Entity;
+    rdfs:label "Beschrijving van het begrip «VCO»"; 
+    foaf:primaryTopic <http://nlbegrip.nl/synthesizer/id/begrip/vco>;
+    rdfs:comment "Deze beschrijving betreft de beschrijving van het begrip";
+    dct:isPartOf <http://nlbegrip.nl/synthesizer/1.0.0-snapshot-1>
+.


### PR DESCRIPTION
Dit is een redactionele oplossing voor https://github.com/Geonovum/NL-SBB/issues/6
- De tekst is aangepast en de term 'punning' wordt niet meer genoemd. 
- 5 ontbrekende ttl files met voorbeelden zijn weer toegevoegd (deze waren bij het opsplitsen van het normatieve deel en de best practice achtergebleven in de normatieve repo)

Echter is de hele paragraaf [1.5 Begrippenbeheer en metadata](http://127.0.0.1:56825/#begrippenbeheer-en-metadata) hier en daar nog onduidelijk. Met name [1.5.4.1.1 Begrippenkader als dataset](http://127.0.0.1:56825/#begrippenkader-als-dataset). De werkgroep zou hier nog eens goed naar moeten kijken en dit stuk inhoudelijk verbeteren. 